### PR TITLE
Fixing 'Mixin "respond-to" does not accept a content block'

### DIFF
--- a/src/_layout/_grid.scss
+++ b/src/_layout/_grid.scss
@@ -5,7 +5,7 @@
   margin: 0 auto;
   padding: 0 $layout-spacing;
 
-  @include respond-to('large') {
+  @include respond('large') {
     padding: 0 ($layout-spacing * 3);
   }
 }


### PR DESCRIPTION
Fixing

```
Error: Mixin "respond-to" does not accept a content block.
        on line 8 of bower_components/macx-sass-mixins/src/_layout/_grid.scss, in `respond-to'
        from line 8 of bower_components/macx-sass-mixins/src/_layout/_grid.scss
        from line 8 of bower_components/macx-sass-mixins/src/sass-mixins.scss
```

when processing sass-mixins.scss with SASS 3.4.9/3.3.0
